### PR TITLE
to support oci oss and postgres ssl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
 		<dependency>
 			<groupId>org.sunbird</groupId>
 			<artifactId>cloud-store-sdk_2.12</artifactId>
-			<version>1.4.3</version>
+			<version>1.4.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>

--- a/src/main/resources/db/migration/006_create_question_assessment.sql
+++ b/src/main/resources/db/migration/006_create_question_assessment.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE table question
+CREATE table IF NOT EXISTS question
 (
     id              uuid DEFAULT uuid_generate_v4 (),
     form_id         VARCHAR(100) NOT NULL,
@@ -11,13 +11,13 @@ CREATE table question
     created         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (id)
-);
+    );
 
-CREATE INDEX idx_form ON question(form_id, form_version);
-CREATE INDEX idx_xPath ON question(x_path);
-CREATE INDEX idx_ques_type ON question(question_type);
+CREATE INDEX IF NOT EXISTS idx_form ON question(form_id, form_version);
+CREATE INDEX IF NOT EXISTS idx_xPath ON question(x_path);
+CREATE INDEX IF NOT EXISTS idx_ques_type ON question(question_type);
 
-CREATE table assessment
+CREATE table IF NOT EXISTS assessment
 (
     id              uuid DEFAULT uuid_generate_v4 (),
     question        uuid,
@@ -30,10 +30,10 @@ CREATE table assessment
     updated         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (id),
     CONSTRAINT fk_question
-        FOREIGN KEY (question)
-            REFERENCES question(id)
-);
+    FOREIGN KEY (question)
+    REFERENCES question(id)
+    );
 
-CREATE INDEX idx_assessment_bot_id ON assessment(bot_id);
-CREATE INDEX idx_assessment_user_id ON assessment(user_id);
-CREATE INDEX idx_assessment_device_id ON assessment(device_id);
+CREATE INDEX IF NOT EXISTS idx_assessment_bot_id ON assessment(bot_id);
+CREATE INDEX IF NOT EXISTS idx_assessment_user_id ON assessment(user_id);
+CREATE INDEX IF NOT EXISTS idx_assessment_device_id ON assessment(device_id);


### PR DESCRIPTION
This change is upgrade cloud-store-sdk to 1.4.6 to support s3 compliant storage and to support postgress ssl connection